### PR TITLE
fix: rename `IsDigest` to `IsPreDigested`

### DIFF
--- a/infisical.go
+++ b/infisical.go
@@ -167,7 +167,7 @@ func (i InfisicalSignerVerifier) SignMessage(message io.Reader, opts ...signatur
 		KeyId:            kmsKey.KeyId,
 		Data:             base64.StdEncoding.Strict().EncodeToString(digest),
 		SigningAlgorithm: signingAlgorithm,
-		IsDigest:         i.hashFunc != crypto.Hash(0),
+		IsPreDigested:    i.hashFunc != crypto.Hash(0),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Renames `IsDigest` to `IsPreDigested`. Depends on the following PR's:

https://github.com/Infisical/infisical/pull/3420
https://github.com/Infisical/go-sdk/pull/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal field naming for improved clarity in message signing processes. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->